### PR TITLE
fix(renovate): use ftpmirror.gnu.org for gettext/libiconv datasources

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -61,11 +61,11 @@
   ],
   "customDatasources": {
     "gettext": {
-      "defaultRegistryUrlTemplate": "https://ftp.gnu.org/pub/gnu/gettext/",
+      "defaultRegistryUrlTemplate": "https://ftpmirror.gnu.org/gettext/",
       "format": "html"
     },
     "libiconv": {
-      "defaultRegistryUrlTemplate": "https://ftp.gnu.org/pub/gnu/libiconv/",
+      "defaultRegistryUrlTemplate": "https://ftpmirror.gnu.org/libiconv/",
       "format": "html"
     },
     "lua": {


### PR DESCRIPTION
## Summary

Closes the `no-result` lookup warnings reported on the Dependency Dashboard (#356):

- `Failed to look up custom.gettext package gettext: no-result`
- `Failed to look up custom.libiconv package libiconv: no-result`

The custom HTML datasources pointed at `ftp.gnu.org`, which rate-limits/blocks automated lookups from CI/datacenter IPs, so Renovate intermittently got no releases back. The version values themselves (`gettext 1.0`, `libiconv 1.19`) are real, current releases and were not the problem.

## Change

Switch the `gettext` and `libiconv` custom datasource registry URLs to `ftpmirror.gnu.org`, matching the download URLs already used in the `Makefile`. `ftpmirror.gnu.org` redirects to a nearby mirror; Renovate follows the redirect and every GNU mirror uses the same Apache autoindex layout, so `format: html` href extraction keeps working.

`lua` is left untouched: it uses `lua.org` and was never affected.

## Verification

- Confirmed `https://ftpmirror.gnu.org/gettext/` and `.../libiconv/` return HTTP 200 with the expected `<a href="...tar.gz">` entries, including the current versions.
- `.renovaterc.json` validated as well-formed JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)