### PR TITLE
fix(renovate): use mirrors.kernel.org for gettext/libiconv datasources

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -61,11 +61,11 @@
   ],
   "customDatasources": {
     "gettext": {
-      "defaultRegistryUrlTemplate": "https://ftpmirror.gnu.org/gettext/",
+      "defaultRegistryUrlTemplate": "https://mirrors.kernel.org/gnu/gettext/",
       "format": "html"
     },
     "libiconv": {
-      "defaultRegistryUrlTemplate": "https://ftpmirror.gnu.org/libiconv/",
+      "defaultRegistryUrlTemplate": "https://mirrors.kernel.org/gnu/libiconv/",
       "format": "html"
     },
     "lua": {


### PR DESCRIPTION
## Problem

The Dependency Dashboard (#356) still reports `no-result` for the `gettext` and `libiconv` custom datasources, even after #510 switched them from `ftp.gnu.org` to `ftpmirror.gnu.org`.

The dashboard was regenerated **after** #510 was merged (dashboard updated `2026-06-30`, #510 merged `2026-06-29`) and the warning persists:

> Renovate failed to look up the following dependencies: `Failed to look up custom.gettext package gettext: no-result`, `Failed to look up custom.libiconv package libiconv: no-result`.

## Root cause

`ftpmirror.gnu.org` is a **redirector**, not a static directory-listing host. A request to `https://ftpmirror.gnu.org/gettext/` returns a `302` to a randomly chosen mirror (e.g. `mirror.twds.com.tw`). Because the target mirror is non-deterministic — and may serve `ftp://` or a page without an HTML autoindex — the `format: "html"` datasource cannot reliably scrape a directory listing, so it returns zero releases (`no-result`).

This does not affect the Makefile downloads, which use `curl -L` to follow a single-file redirect and are unaffected.

## Fix

Point the custom datasource registry URLs at `mirrors.kernel.org`, which serves an Apache autoindex directory listing **directly, without redirects**, so Renovate can parse the available versions:

- `https://mirrors.kernel.org/gnu/gettext/`
- `https://mirrors.kernel.org/gnu/libiconv/`

The Makefile download URLs are intentionally left on `ftpmirror.gnu.org`.

## Verification

Confirmed via HTTP that both URLs return an HTML autoindex directly (no cross-host redirect) and correctly list the current releases (`gettext-1.0.tar.gz`, `libiconv-1.19.tar.gz`), which matches the versions pinned in the Makefile.

Closes the outstanding `no-result` warnings tracked in #356.